### PR TITLE
Minor fixes

### DIFF
--- a/LiberaBLM/edm3.2/panels/loss_events.edl
+++ b/LiberaBLM/edm3.2/panels/loss_events.edl
@@ -95,6 +95,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 showUnits
 newPos
@@ -144,6 +145,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -168,6 +170,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -192,6 +195,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -240,6 +244,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -264,6 +269,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -288,6 +294,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -352,6 +359,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -400,6 +408,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"
@@ -424,6 +433,7 @@ bgColor index 0
 limitsFromDb
 nullColor index 0
 smartRefresh
+fastUpdate
 useHexPrefix
 newPos
 objType "controls"

--- a/LiberaBLM/edm3.2/panels/stream.edl
+++ b/LiberaBLM/edm3.2/panels/stream.edl
@@ -66,7 +66,7 @@ y2Max 1
 # Trace Properties
 numTraces 1
 yPv {
-  0 "EPICS\\$(HOSTNAME):$(SIG)"
+  0 "EPICS\\$(HOSTNAME):$(SIG).$(BLD)"
 }
 ySigned {
   0 1


### PR DESCRIPTION
This makes two changes to beam loss monitor screens.  Firstly, the 10Hz updating events on loss_events.edl are changed to use fastUpdate so that updates are visible, and secondly the stream.edl sub-graphs correctly switch between A/B/C/D when selected.